### PR TITLE
Modernize plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,14 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Show failures on all configurations
+  failFast: false,
+  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  configurations: [
+    [platform: 'windows', jdk: '17', jenkins: '2.381'],
+    [platform: 'linux',   jdk: '11'],
+  ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Skip certificate check plugin
+
+This is a plugin that makes JVM bypass all HTTPS certificate checks.
+Convenient if you deal with self-signed certificates and so on.
+Use with caution.
+
+## Usage
+
+This plugin doesn't require any configuration.
+It activates itself when Jenkins starts.
+
+## Changelog
+
+### Version 1.1 (upcoming)
+
+-   Fixed a ticket just for the sake of demo
+    ([JENKINS-10932](https://issues.jenkins-ci.org/browse/JENKINS-10932))
+
+### Version 1.0 (Sep 7th 2011)
+
+-   initial version

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
   </pluginRepositories>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <jenkins.version>2.346.3</jenkins.version>
   </properties>
 
-  <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,15 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>skip-certificate-check</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <url>https://github.com/jenkinsci/skip-certificate-check-plugin</url>
 
   <properties>
+    <revision>1.1</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/skip-certificate-check-plugin</gitHubRepo>
     <jenkins.version>2.346.3</jenkins.version>
   </properties>
 
@@ -33,8 +36,9 @@
   </pluginRepositories>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>4.51</version>
+    <relativePath />
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -11,20 +12,24 @@
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Skip+Certificate+Check+plugin</url>
+  <url>https://github.com/jenkinsci/skip-certificate-check-plugin</url>
+
+  <properties>
+    <jenkins.version>2.346.3</jenkins.version>
+  </properties>
 
   <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,6 @@
+<?jelly escape-by-default='true'?>
 <div>
-  This is a plugin that makes JVM bypass all the HTTPS certificate checks.
-  Convenient if you deal with self-signed certificates and so on. Use with caution.
+  This is a plugin that makes JVM bypass all HTTPS certificate checks.
+  Convenient if you deal with self-signed certificates and so on.
+  Use with caution.
 </div>


### PR DESCRIPTION
## Modernize plugin

- Use HTTPS URLs in pom.xml
- Test Java 11 and Java 17 in CI
- Require Jenkins 2.346.3 or newer
- Move docs to GitHub
- Remove incorrect comment about artifact repository
- Use correct repository URLs
- Enable incrementals

This plugin has an implied dependency on the WMI Windows Agents plugin because the minimum Jenkins version of this plugin precedes the split of the WMI Windows Agents plugin from Jenkins core.  This pull request moves the minimum Jenkins version to a modern version so that the implied dependency is removed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
