### PR TITLE
Use jenkins.baseline to match archetype

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
----
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    labels:
-      - "dependencies"
-    schedule:
-      interval: "monthly"
+- package-ecosystem: maven
+  directory: /
+  schedule:
+    interval: monthly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,8 @@
     <revision>1.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/skip-certificate-check-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.baseline>2.387</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## Use jenkins.baseline to match archetype

The Jenkins plugin archetype uses jenkins.baseline to prevent inconsistencies between the minimum required Jenkins version and the Jenkins plugin bill of materials version.  Use the same technique in this plugin.

### Testing done

Confirmed that compilation passes.  Will rely on ci.jenkins.io to check automated tests.  Behavior preserving transformation.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
